### PR TITLE
feat: add overlay stack policies

### DIFF
--- a/src/components/overlay/overlay-component.ts
+++ b/src/components/overlay/overlay-component.ts
@@ -1,7 +1,7 @@
 import { Component } from "../component.ts";
 import { DefaultProps, DefaultState } from "../types.ts";
 import { pushOverlay, removeOverlay } from "./index.ts";
-import { CloseableOverlay } from "./types.ts";
+import { CloseableOverlay, OverlayOpenStrategy, OverlayStackAware, OverlayStackOptions } from "./types.ts";
 
 /**
  * Base class for UI overlays (e.g. modals, dropdowns).
@@ -11,12 +11,18 @@ import { CloseableOverlay } from "./types.ts";
  * @template S State type
  */
 
-export abstract class OverlayComponent<P = DefaultProps, S = DefaultState> extends Component<P, S> implements CloseableOverlay {
+export abstract class OverlayComponent<P = DefaultProps, S = DefaultState> extends Component<P, S> implements CloseableOverlay, OverlayStackAware {
 
     zIndex: number = 1000;
 
     /** If true, removes the overlay when clicking outside (default: true) */
     closeOnClickOutside: boolean = true;
+
+    /** When true, allows other overlays to be stacked on top of this one. */
+    allowOverlayOnTop: boolean = false;
+
+    /** Strategy applied when this overlay is opened. */
+    openStrategy: OverlayOpenStrategy = OverlayOpenStrategy.CloseDisallowed;
 
     // Internal flag to ignore the first outside click after rendering
     private listenClickOutside: boolean = false;
@@ -45,6 +51,13 @@ export abstract class OverlayComponent<P = DefaultProps, S = DefaultState> exten
 
     get canCloseOnClickOutside2(): boolean {
         return this.closeOnClickOutside === true && this.listenClickOutside === true;
+    }
+
+    getOverlayStackOptions(): OverlayStackOptions {
+        return {
+            allowOverlayOnTop: this.allowOverlayOnTop,
+            openStrategy: this.openStrategy,
+        };
     }
 
     override remove(): void {

--- a/src/components/overlay/overlay-stack.ts
+++ b/src/components/overlay/overlay-stack.ts
@@ -1,5 +1,19 @@
 import { dom, keyboard } from "../../utils/index.ts";
-import { OverlayComponent } from "../../plugins/index.ts";
+import { OverlayOpenStrategy, OverlayStackAware, OverlayStackOptions } from "./types.ts";
+
+interface OverlayEntry {
+    element: HTMLElement;
+    options: Required<OverlayStackOptions>;
+}
+
+const DEFAULT_OPTIONS: Required<OverlayStackOptions> = {
+    allowOverlayOnTop: false,
+    openStrategy: OverlayOpenStrategy.CloseDisallowed,
+};
+
+function isOverlayStackAware(element: HTMLElement): element is HTMLElement & OverlayStackAware {
+    return typeof (element as OverlayStackAware).getOverlayStackOptions === "function";
+}
 
 /**
  * Manages a stack of overlays (e.g. modals, dialogs) and provides functionality
@@ -8,7 +22,7 @@ import { OverlayComponent } from "../../plugins/index.ts";
  */
 export class OverlayStack {
 
-    private stack: HTMLElement[] = [];
+    private stack: OverlayEntry[] = [];
 
     /**
      * Registers event listeners for keydown (to close with Escape key) and click
@@ -24,7 +38,14 @@ export class OverlayStack {
      * @param element The overlay element to add to the stack.
      */
     public push(element: HTMLElement) {
-        this.stack.push(element);
+        const entry: OverlayEntry = {
+            element,
+            options: this.resolveOptions(element),
+        };
+
+        this.prepareStackFor(entry.options.openStrategy);
+
+        this.stack.push(entry);
     }
 
     /**
@@ -32,17 +53,17 @@ export class OverlayStack {
      * @returns The topmost overlay element or undefined if the stack is empty.
      */
     public peek(): HTMLElement | undefined {
-        return this.stack[this.stack.length - 1];
+        return this.peekEntry()?.element;
     }
 
     /**
      * Pops and removes the topmost overlay element from the stack.
      */
     public pop() {
-        const element = this.stack.pop();
+        const entry = this.stack.pop();
 
-        if (element) {
-            element.remove();
+        if (entry) {
+            entry.element.remove();
         }
     }
 
@@ -51,10 +72,10 @@ export class OverlayStack {
      * @param element The overlay element to remove.
      */
     public remove(element: HTMLElement) {
-        const idx = this.stack.lastIndexOf(element);
+        const idx = this.stack.map((entry) => entry.element).lastIndexOf(element);
         if (idx !== -1) {
-            this.stack.splice(idx, 1);
-            element.remove();
+            const [entry] = this.stack.splice(idx, 1);
+            entry.element.remove();
         }
     }
 
@@ -77,8 +98,66 @@ export class OverlayStack {
         if (!top) return;
 
         const clickedInside = top.contains(event.target as Node);
-        if (!clickedInside && (top as OverlayComponent).canCloseOnClickOutside2) {
+        if (!clickedInside && this.canCloseOnOutside(top)) {
             this.remove(top);
         }
     };
+
+    private canCloseOnOutside(element: HTMLElement): boolean {
+        const overlay = element as OverlayStackAware;
+
+        if (typeof overlay.canCloseOnClickOutside2 === "boolean") {
+            return overlay.canCloseOnClickOutside2;
+        }
+
+        if (typeof overlay.closeOnClickOutside === "boolean") {
+            return overlay.closeOnClickOutside;
+        }
+
+        return false;
+    }
+
+    private resolveOptions(element: HTMLElement): Required<OverlayStackOptions> {
+        if (isOverlayStackAware(element)) {
+            const options = element.getOverlayStackOptions?.();
+            if (options) {
+                return { ...DEFAULT_OPTIONS, ...options };
+            }
+        }
+
+        return DEFAULT_OPTIONS;
+    }
+
+    private peekEntry(): OverlayEntry | undefined {
+        return this.stack[this.stack.length - 1];
+    }
+
+    private prepareStackFor(strategy: OverlayOpenStrategy) {
+        if (strategy === OverlayOpenStrategy.ClearStack) {
+            this.clear();
+            return;
+        }
+
+        if (strategy === OverlayOpenStrategy.KeepStack) {
+            return;
+        }
+
+        // OverlayOpenStrategy.CloseDisallowed (default)
+        while (this.stack.length > 0) {
+            const topEntry = this.peekEntry();
+            if (!topEntry) return;
+
+            if (topEntry.options.allowOverlayOnTop) {
+                return;
+            }
+
+            this.pop();
+        }
+    }
+
+    private clear() {
+        while (this.stack.length > 0) {
+            this.pop();
+        }
+    }
 }

--- a/src/components/overlay/types.ts
+++ b/src/components/overlay/types.ts
@@ -4,3 +4,43 @@
 export interface CloseableOverlay {
     closeOnClickOutside?: boolean;
 }
+
+/**
+ * Defines how the overlay stack should react when a new overlay is opened.
+ */
+export enum OverlayOpenStrategy {
+    /** Keep the current stack untouched when the overlay opens. */
+    KeepStack = "keepStack",
+
+    /**
+     * Close overlays that don't allow stacking before inserting the new
+     * overlay. This is the default behaviour.
+     */
+    CloseDisallowed = "closeDisallowed",
+
+    /** Close the entire stack before inserting the new overlay. */
+    ClearStack = "clearStack",
+}
+
+/**
+ * Options that describe how an overlay interacts with the stack.
+ */
+export interface OverlayStackOptions {
+    /**
+     * When true, the overlay remains in the stack even if other overlays are
+     * opened later.
+     */
+    allowOverlayOnTop?: boolean;
+
+    /** Strategy that should be applied when this overlay is opened. */
+    openStrategy?: OverlayOpenStrategy;
+}
+
+/**
+ * Overlays that expose stack options. The stack manager uses this information
+ * to decide whether other overlays must be closed when a new one is opened.
+ */
+export interface OverlayStackAware extends CloseableOverlay {
+    getOverlayStackOptions?: () => OverlayStackOptions;
+    canCloseOnClickOutside2?: boolean;
+}

--- a/src/design-system/components/toolbar-ui.tsx
+++ b/src/design-system/components/toolbar-ui.tsx
@@ -5,6 +5,8 @@ import { DefaultProps, OverlayComponent } from "../../plugins/index.ts";
 
 export class ToolbarUI<P extends DefaultProps = DefaultProps, S = DefaultState> extends OverlayComponent<P, S> {
 
+    override allowOverlayOnTop = true;
+
     static override styles = this.extendStyles(/*css*/`
         .guten-toolbar ul{
             padding: 0;
@@ -34,3 +36,4 @@ export class ToolbarUI<P extends DefaultProps = DefaultProps, S = DefaultState> 
         );
     }
 }
+

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -4,6 +4,7 @@ export { h, Fragment } from "../jsx.ts";
 /* components */
 export { Component } from "../components/component.ts";
 export { OverlayComponent } from "../components/overlay/overlay-component.ts";
+export { OverlayOpenStrategy } from "../components/overlay/types.ts";
 export type { DefaultProps } from "../components/types.ts";
 
 /* i18n */

--- a/src/plugins/slash-menu/components/slash-menu.tsx
+++ b/src/plugins/slash-menu/components/slash-menu.tsx
@@ -1,5 +1,5 @@
 /** @jsx h */
-import { dom, keyboard, h, t, OverlayComponent } from "../../index.ts";
+import { dom, keyboard, h, t, OverlayComponent, OverlayOpenStrategy } from "../../index.ts";
 import { SlashMenuItem } from "./slash-menu-item.tsx";
 import { findClosestAncestorOfSelectionByClass } from "../../../utils/dom-utils.ts";
 
@@ -19,6 +19,8 @@ interface SlashMenuState {
 }
 
 export class SlashMenuOverlay extends OverlayComponent<SlashMenuProps, SlashMenuState> {
+
+    override openStrategy = OverlayOpenStrategy.ClearStack;
 
     private focusedBlock: HTMLElement | null;
     private range: Range | null;


### PR DESCRIPTION
## Summary
- allow overlays to expose stack policies describing whether they can be overlaid and which elements to close
- update the overlay stack manager to honour those policies, supporting clearing the stack or removing only disallowed overlays
- propagate the new behaviour to the formatting toolbar and slash menu and re-export the stack strategy enum for plugins

## Testing
- deno task test *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_e_68d07b0b6e588332b3aaeeec6ab6e2b0