### PR TITLE
Anchor block options overlay to drag handle

### DIFF
--- a/src/design-system/components/menu-item-ui.tsx
+++ b/src/design-system/components/menu-item-ui.tsx
@@ -3,7 +3,6 @@ import { h } from "../../jsx.ts";
 import { Component } from "../../components/component.ts";
 import { DefaultProps, DefaultState } from "../../components/types.ts";
 import { dom, keyboard } from "../../utils/index.ts";
-import { OverlayComponent } from "../../components/overlay/overlay-component.ts";
 
 export interface MenuItemUIProps extends DefaultProps {
     icon?: SVGElement;
@@ -12,7 +11,7 @@ export interface MenuItemUIProps extends DefaultProps {
     onSelect: () => void;
 }
 
-export class MenuItemUI<P extends MenuItemUIProps, S = DefaultState> extends OverlayComponent<P, S> {
+export class MenuItemUI<P extends MenuItemUIProps, S = DefaultState> extends Component<P, S> {
 
     static override styles = this.extendStyles(/*css*/`
         .guten-menu-item {
@@ -72,12 +71,6 @@ export class MenuItemUI<P extends MenuItemUIProps, S = DefaultState> extends Ove
         
     `);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-
-        this.registerEvent(this, dom.EventTypes.MouseDown, (e: Event) => this.handleOnSelect(e, this.props.onSelect));
-    }
-
     override render(): HTMLElement {
         const { icon, label } = this.props as MenuItemUIProps;
 
@@ -88,6 +81,12 @@ export class MenuItemUI<P extends MenuItemUIProps, S = DefaultState> extends Ove
                 </button>
             </div>
         );
+    }
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+
+        this.registerEvent(this, dom.EventTypes.MouseDown, (e: Event) => this.handleOnSelect(e, this.props.onSelect));
     }
 
     handleOnSelect(event: Event, onSelect: () => void) {

--- a/src/plugins/drag-and-drop/commands/open-block-options.tsx
+++ b/src/plugins/drag-and-drop/commands/open-block-options.tsx
@@ -8,13 +8,13 @@ import { BlockOptionsItem } from "../components/block-options-item.tsx";
 export const OpenBlockOptions: Command = {
     id: "openBlockOptions",
     shortcut: { chord: "Mod+Shift+O", description: "Open block options" },
-    execute(context: CommandContext<{ block?: HTMLElement; rect?: DOMRect }>): boolean {
+    execute(context: CommandContext<{ block?: HTMLElement; rect?: DOMRect; anchor?: Node }>): boolean {
 
 
         let blockOptions: HTMLElement | null = null;
 
         const el = appendElementOnOverlayArea(
-            <BlockOptions >
+            <BlockOptions anchor={context.content?.anchor ?? undefined} fallbackRect={context.content?.rect}>
                 <BlockOptionsItem icon={<CopyIcon />} label={t("duplicate")} onSelect={() => runCommand("duplicateBlock", {
                     content: { block: context.content?.block, blockOptions: blockOptions }
                 })} />
@@ -35,12 +35,6 @@ export const OpenBlockOptions: Command = {
         );
 
         blockOptions = el;
-
-        const rect = context.content?.rect;
-        if (rect) {
-            el.style.top = `${rect.top}px`;
-            el.style.left = `${rect.right + 8}px`;
-        }
 
         return true;
     }

--- a/src/plugins/drag-and-drop/components/block-options.tsx
+++ b/src/plugins/drag-and-drop/components/block-options.tsx
@@ -6,6 +6,8 @@ import { DefaultProps } from "../../../components/types.ts";
 
 interface BlockOptionsProps extends DefaultProps {
     keyboardNavigation?: boolean;
+    anchor?: Node;
+    fallbackRect?: DOMRect;
 }
 
 export class BlockOptions extends MenuUI {
@@ -14,14 +16,26 @@ export class BlockOptions extends MenuUI {
     private keyboardController?: MenuKeyboardController;
 
     override onMount(): void {
-        const { keyboardNavigation = true } = this.props as BlockOptionsProps;
+        const { keyboardNavigation = true, anchor, fallbackRect } = this.props as BlockOptionsProps;
         if (keyboardNavigation) {
             this.keyboardController = new MenuKeyboardController(this);
             this.keyboardController.connect();
+        }
+
+        if (anchor) {
+            this.positionToAnchor(anchor);
+        } else if (fallbackRect) {
+            this.positionWithRect(fallbackRect);
         }
     }
 
     override onUnmount(): void {
         this.keyboardController?.disconnect();
+    }
+
+    private positionWithRect(rect: DOMRect) {
+        const gap = 8;
+        this.style.top = `${rect.top}px`;
+        this.style.left = `${rect.right + gap}px`;
     }
 }

--- a/src/plugins/drag-and-drop/drag-and-drop-manager.ts
+++ b/src/plugins/drag-and-drop/drag-and-drop-manager.ts
@@ -117,10 +117,11 @@ export class DragAndDropManager {
     private onHandleContextMenu = (e: MouseEvent) => {
         e.preventDefault();
         if (!this.currentTarget || !this.handleWrap) return;
-        const rect = this.handleWrap.getBoundingClientRect();
         const block = this.currentTarget;
+        const anchor = this.handleWrap;
+        const rect = anchor.getBoundingClientRect();
+        runCommand('openBlockOptions', { content: { block, anchor, rect } });
         this.hideHandle();
-        runCommand('openBlockOptions', { content: { block, rect } });
     };
 
     private startHideTimer() {


### PR DESCRIPTION
## Summary
- anchor the block options overlay to the drag handle element so it positions next to the trigger
- fall back to the previously computed handle rect when no anchor node is available

## Testing
- Not run (deno not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d80f183f5c8332aebca5b546c73f85